### PR TITLE
Upload / download nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ for repo_name in ["lol/yolo"]:
 Run this from the folder you want to upload from. You can choose individual files, or use the `.` wildcard to upload everything in the current folder.
 
 ```bash
-huggingface-cli upload --create-pr meta-llama/Llama-Guard-3-11B-Vision .
+huggingface-cli upload --private --create-pr meta-llama/Llama-Guard-3-11B-Vision .
 ```
 
 ## Download stuff locally
 
 ```bash
-huggingface-cli download meta-llama/Llama-3.2-3B-Instruct --local-dir Llama-3.2-3B-Instruct --local-dir-use-symlinks False
+huggingface-cli download meta-llama/Llama-3.2-3B-Instruct --local-dir Llama-3.2-3B-Instruct
 ```
 
 P.S. for large repos - make sure to setup `hf_transfer` -> `pip install hf_transfer`


### PR DESCRIPTION
* I always default to using `--private` while working on pre-releases. If the repo exists, it's a no-op. But if it is doesn't (or if you mess up with the name), there's no risk a pre-release checkpoint can make it to a public repo.
* The "don't use symlinks" flag is no longer necessary for downloads.